### PR TITLE
Fix repository name of 'execjs'

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,4 +19,4 @@ This library depends on the `babel-source` gem which is updated any time a new v
 
 ### ExecJS
 
-The [ExecJS](https://github.com/sstephenson/execjs) library is used to automatically choose the best JavaScript engine for your platform. Check out its [README](https://github.com/sstephenson/execjs/blob/master/README.md) for a complete list of supported engines.
+The [ExecJS](https://github.com/rails/execjs) library is used to automatically choose the best JavaScript engine for your platform. Check out its [README](https://github.com/rails/execjs/blob/master/README.md) for a complete list of supported engines.

--- a/SOURCE-BUILDS.md
+++ b/SOURCE-BUILDS.md
@@ -1,6 +1,6 @@
 # Babel Source Builds
 
-The Ruby transpiler bridge is just a thin [ExecJS](https://github.com/sstephenson/execjs) wrapper around the [Babel](https://babeljs.io) JS source. The source itself is redistributed as a  [babel-source](https://rubygems.org/gems/babel-source) RubyGem with the corresponding version. This means users can easily upgrade to the latest Babel anytime its released while maintaining Ruby API compatibility.
+The Ruby transpiler bridge is just a thin [ExecJS](https://github.com/rails/execjs) wrapper around the [Babel](https://babeljs.io) JS source. The source itself is redistributed as a  [babel-source](https://rubygems.org/gems/babel-source) RubyGem with the corresponding version. This means users can easily upgrade to the latest Babel anytime its released while maintaining Ruby API compatibility.
 
 Babel JS releases tend be released more frequently than changes to the Ruby bridge itself. So theres some automation behind releasing the source gems.
 


### PR DESCRIPTION
It is moved to under 'rails' organization.

```
$ sed -i '' s/sstephenson/rails/g *.md
```