### PR TITLE
Allow beta (or rc) version in payload of GH tag event

### DIFF
--- a/config.ru
+++ b/config.ru
@@ -12,7 +12,7 @@ module App
     request = Rack::Request.new(env)
     payload = JSON.parse(request.body.read)
 
-    if payload["ref"] && (version = payload["ref"][/(\d+\.\d+\.\d+)/, 1])
+    if payload["ref"] && (version = payload["ref"][/\Av(\d+\.\d+\.\d+.*)\z/, 1])
       output = `#{__dir__}/pr-release #{Shellwords.join([USER, TOKEN, version])} 2>&1`
       fail "pr-release failed:\n#{output}" unless $?.success?
     end


### PR DESCRIPTION
babel [v5.0.0.beta3](https://github.com/babel/babel/tree/v5.0.0-beta3) is now released but it couldn't handled by auto PR script.
It makes wrong tag version such as https://github.com/babel/babel/tree/v5.0.0-beta3 .

This patch *probably* works as my expectation.(I couldn't test it with actual data.)

@josh 
If this seems good, could you deploy to heroku ?