### PR TITLE
Avoid return outside of function

### DIFF
--- a/test/test_babel_transpiler.rb
+++ b/test/test_babel_transpiler.rb
@@ -28,11 +28,11 @@ class TestBabelTranspiler < MiniTest::Test
   end
 
   def test_transform
-    code = Babel::Transpiler.transform("return [0, 2, 4].map(v => v + 1)")["code"]
-    assert_equal [1, 3, 5], ExecJS.exec(code)
+    code = Babel::Transpiler.transform("[0, 2, 4].map(v => v + 1)", "blacklist" => ["useStrict"])["code"]
+    assert_equal [1, 3, 5], ExecJS.exec("return #{code}")
 
-    code = Babel::Transpiler.transform("return (function f(x, y = 12) { return x + y; })(3)")["code"]
-    assert_equal 15, ExecJS.exec(code)
+    code = Babel::Transpiler.transform("(function f(x, y = 12) { return x + y; })(3)", "blacklist" => ["useStrict"])["code"]
+    assert_equal 15, ExecJS.exec("return #{code}")
   end
 
   def test_transform_options


### PR DESCRIPTION
In https://github.com/babel/ruby-babel-transpiler/pull/141, looks like theres a new failure trying to compile `return [0, 2, 4].map(v => v + 1)`. New Babel doesn't like `unknown: 'return' outside of function`. Seems legit. We can just change our test to avoid this, it wasn't a detail of what we were trying to test away. This should still work on old Babels.

/cc @tricknotes 