### PR TITLE
Use polyfill for environments that has no `setTimeout`/`setInterval`

### DIFF
--- a/lib/babel/transpiler.rb
+++ b/lib/babel/transpiler.rb
@@ -21,11 +21,26 @@ module Babel
     end
 
     def self.context
-      @context ||= ExecJS.compile("var self = this; " + File.read(script_path))
+      @context ||= ExecJS.compile(POLYFILL + File.read(script_path))
     end
 
     def self.transform(code, options = {})
       context.call('babel.transform', code, options.merge('ast' => false))
     end
+
+    POLYFILL = <<-JS.freeze
+var self = this;
+
+if (typeof setTimeout == 'undefined') {
+  setTimeout = function(callback) {
+    callback();
+  };
+}
+if (typeof setInterval == 'undefined') {
+  setInterval = function(callback) {
+    callback();
+  };
+}
+    JS
   end
 end


### PR DESCRIPTION
On JavaScriptCore runtime, `Babel::Transpiler.transform` will crash with the following error:

```irb
>> Babel::Transpiler.transform('')['code']
ExecJS::ProgramError: ReferenceError: Can't find variable: setTimeout
```

So I used stub for `setTimeout` and `setInterval` in favor of [this babel's commit](https://github.com/babel/babel/commit/ebc42f5ce05b4266c0bc86aa9754bf448d6e60f5).
But I'm not sure why the commit is landed. cc/ @sebmck 

----

There are my versions:
``` irb
>> Babel::Transpiler::VERSION
=> "0.7.0"
>> Babel::Source::VERSION
=> "5.0.4"
>> ExecJS.runtime.name
=> "JavaScriptCore"
```