### PR TITLE
Fix travis build

### DIFF
--- a/script/deploy
+++ b/script/deploy
@@ -18,10 +18,10 @@ EOF
   chmod 0600 ~/.gem/credentials
 fi
 
-for gem_version in $(./script/unpublished-gem-versions)
+for source_version in $(./script/unpublished-suorce-versions)
 do
-  if [ ! -f "tmp/vendor/cache/babel-source-$gem_version.gem" ]; then
+  if [ ! -f "tmp/vendor/cache/babel-source-$source_version.gem" ]; then
     ./script/test-gem "$version"
   fi
-  gem push "tmp/vendor/cache/babel-source-$gem_version.gem"
+  gem push "tmp/vendor/cache/babel-source-$source_version.gem"
 done

--- a/script/unpublished-gem-versions
+++ b/script/unpublished-gem-versions
@@ -1,2 +1,0 @@
-#!/bin/bash
-comm -13 <(./script/published-source-versions | sort) <(./script/local-source-versions | ./script/gem-version | sort)

--- a/script/unpublished-source-versions
+++ b/script/unpublished-source-versions
@@ -1,2 +1,2 @@
 #!/bin/bash
-comm -13 <(./script/published-source-versions | sort) <(./script/local-source-versions | sort)
+comm -13 <(./script/published-source-versions | sort) <(./script/local-source-versions | ./script/gem-version | sort)


### PR DESCRIPTION
The build for some beta versions are failed on Travis.
But there are already released as gems so these builds are unnecessary.

Close https://github.com/babel/ruby-babel-transpiler/pull/164
