### PR TITLE
fixes #284 added JavaScript console util that mimics browser equivalent

### DIFF
--- a/lib/babel/transpiler.rb
+++ b/lib/babel/transpiler.rb
@@ -21,11 +21,41 @@ module Babel
     end
 
     def self.context
-      @context ||= ExecJS.compile("var self = this; " + File.read(script_path))
+      script_header = <<-EOS
+        var self = this;
+        // including console implementation for ExecJS environment
+        var console = (function (){
+          var buffer = [];
+          function getBuffer() { return buffer.concat(); }
+          function clearBuffer() { buffer = []; }
+          function writeToBuffer(level, args) {
+            buffer.push(level + ": " + Array.prototype.join.call(args, ', '));
+          }
+          function log() { writeToBuffer('LOG', arguments); }
+          function error() { writeToBuffer('ERROR', arguments); }
+          function debug() { writeToBuffer('DEBUG', arguments); }
+          function info() { writeToBuffer('INFO', arguments); }
+          return {
+            log:log,
+            error:error,
+            debug:debug,
+            info:info,
+            getBuffer:getBuffer,
+            clearBuffer:clearBuffer
+          };
+        })();
+      EOS
+
+      @context ||= ExecJS.compile(script_header + File.read(script_path))
     end
 
     def self.transform(code, options = {})
+      context.call('console.clearBuffer')
       context.call('babel.transform', code, options.merge('ast' => false))
+    end
+
+    def self.console_output
+      context.call('console.getBuffer')
     end
   end
 end


### PR DESCRIPTION
Fixes (https://github.com/babel/ruby-babel-transpiler/issues/284) added JavaScript console utility that mimics browser equivalent and prevent null pointer exeptions.

This fixes an issue when Babel compiler emit some messages about come conditions like code generator deoptimisation by using console.error() method that doesn't exist in ExecJS environment.

Logged messages are accessible via `Babel::Transpiler.console_output` method after transform is executed (but not during).