### PR TITLE
Fix unlabeled ExecJS runtime error

### DIFF
--- a/lib/babel/transpiler.rb
+++ b/lib/babel/transpiler.rb
@@ -21,7 +21,7 @@ module Babel
     end
 
     def self.context
-      @context ||= ExecJS.compile("var self = this; " + File.read(script_path))
+      @context ||= ExecJS.compile("var self = this; " + File.read(script_path, encoding: 'utf-8'))
     end
 
     def self.transform(code, options = {})


### PR DESCRIPTION
Without this fix, calling `Babel::Transpiler.transform` with **any** input will raise `ExecJS::RuntimeError` with no message.